### PR TITLE
Fix for caching error

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -372,7 +372,12 @@ class Browscap
             } elseif ($value === 'false') {
                 $value = false;
             }
-            $array[$this->_properties[$key]] = $value;
+            
+            $tmp_key = $this->_properties[$key];
+            if ($this->lowercase) {
+                $tmp_key = strtolower($this->_properties[$key]);
+            }
+            $array[$tmp_key] = $value;
         }
 
         return $return_array ? $array : (object) $array;
@@ -608,11 +613,6 @@ class Browscap
 
                 $this->_patterns[$pattern] = $pattern_data;
             }
-        }
-
-        // Save the keys lowercased if needed
-        if ($this->lowercase) {
-            $this->_properties = array_map('strtolower', $this->_properties);
         }
 
         // Get the whole PHP code


### PR DESCRIPTION
After the cache file was generated, it wasn't possible to switch the lowercase option anymore. Now the data are always cached with camel-case keys, and modified to lowercase after reading the cache in the getBrowser() method.
