### PR TITLE
Give temporary names to the temporary files to prevent race condition problems.

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -918,7 +918,7 @@ class Browscap
      * @param string cache_path_useragent Temporary useragent data location
      * @param string cache_path_patterns Temporary pattern data location
      *
-     * @var string|null
+     * @return string the PHP string to save into the cache file
      */
     protected function _buildCache($cache_path_properties, $cache_path_browsers, $cache_path_useragent, $cache_path_patterns)
     {


### PR DESCRIPTION
In a race condition, multiple browscap instances could be simultaneously running before the lock file is created (due to the fact that the lock isn't an exclusive one). This should prevent any weirdness from happening due to writing to the same file. I also changed instances of time() to microtime() for the same reason.

I don't know if this makes the cachePropertiesFilename, cacheBrowserFilename, etc properties useless, but I kept them there anyway.
