### PR TITLE
Show concerned lock file when error is launched

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -525,7 +525,7 @@ class Browscap
         $lockfile = $this->cacheDir . 'cache.lock';
 
         if (file_exists($lockfile) || !touch($lockfile)) {
-            throw new Exception('temporary file already exists');
+            throw new Exception(sprintf('temporary file %s already exists', $lockfile));
         }
 
         $ini_path   = $this->cacheDir . $this->iniFilename;


### PR DESCRIPTION
Not a big modification, just put the concerned lockfile when the error is launched.

This permit to easily find the concerned file and delete it if needed.

Thanks.
