### PR TITLE
Use flock() for the cache lockfile (errors while writing the cache file ...

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -530,7 +530,7 @@ class Browscap
         if (false === $lockRes) {
             throw new Exception(sprintf('error opening lockfile %s', $lockfile));
         }
-        if(false === flock($lockRes, LOCK_EX | LOCK_NB)) {
+        if (false === flock($lockRes, LOCK_EX | LOCK_NB)) {
             throw new Exception(sprintf('error locking lockfile %s', $lockfile));
         }
 
@@ -646,11 +646,11 @@ class Browscap
         $tmpFile = $dir . '/temp_' . md5(time() . basename($cache_path));
 
         // asume that all will be ok
-        if (false === ($fileRes=fopen($tmpFile, 'w+'))) {
+        if (false === ($fileRes = fopen($tmpFile, 'w+'))) {
             // opening the temparary file failed
             throw new Exception('opening temporary file failed');
         }
-        if(false === $this->_buildCache($fileRes)) {
+        if (false === $this->_buildCache($fileRes)) {
             // writing to the temparary file failed
             throw new Exception('writing to temporary file failed');
         }
@@ -845,7 +845,7 @@ class Browscap
      */
     protected function _buildCache($fileRes)
     {
-        if(false === fwrite($fileRes, sprintf(
+        if (false === fwrite($fileRes, sprintf(
             "<?php\n\$source_version=%s;\n\$cache_version=%s",
             "'" . $this->_source_version . "'",
             "'" . self::CACHE_FILE_VERSION . "'"
@@ -854,39 +854,39 @@ class Browscap
             return false;
         }
         
-        if(false === fwrite($fileRes, ";\n\$properties=")) {
+        if (false === fwrite($fileRes, ";\n\$properties=")) {
             // write error
             return false;
         }
-        if(false === $this->_array2string($this->_properties, $fileRes)) {
+        if (false === $this->_array2string($this->_properties, $fileRes)) {
             // write error
             return false;
         }
-        if(false === fwrite($fileRes, ";\n\$browsers=")) {
+        if (false === fwrite($fileRes, ";\n\$browsers=")) {
             // write error
             return false;
         }
-        if(false === $this->_array2string($this->_browsers, $fileRes)) {
+        if (false === $this->_array2string($this->_browsers, $fileRes)) {
             // write error
             return false;
         }
-        if(false === fwrite($fileRes, ";\n\$userAgents=")) {
+        if (false === fwrite($fileRes, ";\n\$userAgents=")) {
             // write error
             return false;
         }
-        if(false === $this->_array2string($this->_userAgents, $fileRes)) {
+        if (false === $this->_array2string($this->_userAgents, $fileRes)) {
             // write error
             return false;
         }
-        if(false === fwrite($fileRes, ";\n\$patterns=")) {
+        if (false === fwrite($fileRes, ";\n\$patterns=")) {
             // write error
             return false;
         }
-        if(false === $this->_array2string($this->_patterns, $fileRes)) {
+        if (false === $this->_array2string($this->_patterns, $fileRes)) {
             // write error
             return false;
         }
-        if(false === fwrite($fileRes, ";\n")) {
+        if (false === fwrite($fileRes, ";\n")) {
             // write error
             return false;
         }
@@ -1027,7 +1027,7 @@ class Browscap
      */
     protected function _array2string($array, $fileRes)
     {
-        if(false === fwrite($fileRes, "array(\n")) {
+        if (false === fwrite($fileRes, "array(\n")) {
             // write error
             return false;
         }
@@ -1048,12 +1048,12 @@ class Browscap
                 $value = "'" . str_replace("'", "\'", $value) . "'";
             }
 
-            if(false === fwrite($fileRes, $key . $value . ",\n")) {
+            if (false === fwrite($fileRes, $key . $value . ",\n")) {
                 // write error
                 return false;
             }
         }
-        if(false === fwrite($fileRes, "\n)")) {
+        if (false === fwrite($fileRes, "\n)")) {
             // write error
             return false;
         }

--- a/tests/phpbrowscapTest/BrowscapTest.php
+++ b/tests/phpbrowscapTest/BrowscapTest.php
@@ -244,7 +244,7 @@ class BrowscapTest extends TestCase
 
         $browscap = new Browscap($cacheDir);
 
-        $result = 'array(' . "\n" . '\'a\'=>1,' . "\n" . '\'b\'=>\'abc\',' . "\n" . '1=>\'cde\',' . "\n" . '\'def\',' . "\n" . '\'a:3:{i:0;s:3:"abc";i:1;i:1;i:2;i:2;}\'' . "\n" . ')';
+        $result = 'array(' . "\n" . '\'a\'=>1,' . "\n" . '\'b\'=>\'abc\',' . "\n" . '1=>\'cde\',' . "\n" . '\'def\',' . "\n" . '\'a:3:{i:0;s:3:"abc";i:1;i:1;i:2;i:2;}\',' . "\n" . "\n" . ')';
 
         // "tempnam" did not work with VFSStream for tests
         $tmpFile = $cacheDir . '/temp_test_' . md5(time());

--- a/tests/phpbrowscapTest/BrowscapTest.php
+++ b/tests/phpbrowscapTest/BrowscapTest.php
@@ -253,9 +253,12 @@ class BrowscapTest extends TestCase
             throw new \RuntimeException(sprintf('Unable to create temporary file "%s"', $tmpFile));
         }
         
-        self::assertSame($result, $method->invoke($browscap, array('a' => 1, 'b' => 'abc', '1.0' => 'cde', 1 => 'def', 2 => array('abc', 1, 2)), $fileRes));
+        self::assertTrue($method->invoke($browscap, array('a' => 1, 'b' => 'abc', '1.0' => 'cde', 1 => 'def', 2 => array('abc', 1, 2)), $fileRes));
         
         fclose($fileRes);
+        
+        self::assertSame($result, file_get_contents($tmpFile));
+        
         unlink($tmpFile);
     }
 

--- a/tests/phpbrowscapTest/BrowscapTest.php
+++ b/tests/phpbrowscapTest/BrowscapTest.php
@@ -246,7 +246,17 @@ class BrowscapTest extends TestCase
 
         $result = 'array(' . "\n" . '\'a\'=>1,' . "\n" . '\'b\'=>\'abc\',' . "\n" . '1=>\'cde\',' . "\n" . '\'def\',' . "\n" . '\'a:3:{i:0;s:3:"abc";i:1;i:1;i:2;i:2;}\'' . "\n" . ')';
 
-        self::assertSame($result, $method->invoke($browscap, array('a' => 1, 'b' => 'abc', '1.0' => 'cde', 1 => 'def', 2 => array('abc', 1, 2))));
+        // "tempnam" did not work with VFSStream for tests
+        $tmpFile = $cacheDir . '/temp_test_' . md5(time());
+
+        if (false == ($fileRes = fopen($tmpFile, 'w+'))) {
+            throw new \RuntimeException(sprintf('Unable to create temporary file "%s"', $tmpFile));
+        }
+        
+        self::assertSame($result, $method->invoke($browscap, array('a' => 1, 'b' => 'abc', '1.0' => 'cde', 1 => 'def', 2 => array('abc', 1, 2)), $fileRes));
+        
+        fclose($fileRes);
+        unlink($tmpFile);
     }
 
     /**


### PR DESCRIPTION
...would otherwise block further cache updates because of the stale lockfile lying around).

Also reduced memory footprint while generating the new cache file by writing this file in smaller chunks rather than calculating the whole cache file in memory (as string) before writing it to the cache file.