### PR TITLE
optimize loading of the cache

### DIFF
--- a/src/phpbrowscap/Browscap.php
+++ b/src/phpbrowscap/Browscap.php
@@ -316,7 +316,7 @@ class Browscap
         }
 
         $cache_file = $this->cacheDir . $this->cacheFilename;
-        if (!$this->_loadCache($cache_file)) {
+        if (!$this->_cacheLoaded && !$this->_loadCache($cache_file)) {
             throw new Exception('Cannot load cache file - the cache format is not compatible.');
         }
 
@@ -658,6 +658,7 @@ class Browscap
         }
 
         @unlink($lockfile);
+        $this->_cacheLoaded = false;
 
         return true;
     }


### PR DESCRIPTION
Actual every time the `getBrowser()` function is called, the cache file is included. For normal usage this is ok.

But when using this class for testing browscap/browscap, this summarizes up to 64% of the complete time of the test.

This PR will make sure that the cache file is only included, it was not included before.