### PR TITLE
[2.x] add php nightly to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - nightly
   - hhvm
 
 before_script:


### PR DESCRIPTION
I wanted to remove the tests on OSX, but that wasn't added here. So I just added PHP Nightly tests.