### PR TITLE
[3.x] add php nightly to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/
 vendor/
 phpunit.xml
+PHP_BrowscapINI

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,19 @@ sudo: false
 php:
   - 5.5
   - 5.6
-  - 7
+  - 7.0
+  - nightly
   - hhvm
 
 os:
   - linux
-#  - osx -- disabled, bug created in https://github.com/browscap/browscap-php/issues/96
 
 before_script:
   - wget http://browscap.org/stream?q=Full_PHP_BrowsCapINI -O /tmp/browscap.ini
-  - if [ "`phpenv version-name`" == "5.5" ] || [ "`phpenv version-name`" == "5.6" ]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [ "`phpenv version-name`" == "5.5" ] || [ "`phpenv version-name`" == "5.6" ]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [ "`phpenv version-name`" != "hhvm" ]; then echo 'opcache.enable=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [ "`phpenv version-name`" != "hhvm" ]; then echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [ "`phpenv version-name`" == "hhvm" ]; then echo 'opcache.enable=1' >> /etc/hhvm/php.ini; fi
+  - if [ "`phpenv version-name`" == "hhvm" ]; then echo 'opcache.enable_cli=1' >> /etc/hhvm/php.ini; fi
   - composer self-update
   - composer install -o --prefer-source
   - cp /tmp/browscap.ini resources/browscap.ini


### PR DESCRIPTION
I removed the travis tests on OSX, because they are failing and I dont know why I added these. I also added tests on PHP Nightly and opcache for the HHVM.

This PR is related to Issue #96.