### PR TITLE
Travis cache 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.phar
 composer.lock
 resources/
 PHP_BrowscapINI
+resources

--- a/.travis-scripts/cache-browscap.sh
+++ b/.travis-scripts/cache-browscap.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -f "$TRAVIS_BUILD_DIR/resources/browscap.ini" ]; then
+  mkdir -p $TRAVIS_BUILD_DIR/resources
+  wget http://browscap.org/stream?q=Full_PHP_BrowsCapINI -O $TRAVIS_BUILD_DIR/resources/browscap.ini
+else
+  echo "Using cached browscap.ini"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,19 @@ php:
   - nightly
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: 5.3
-    - php: 5.4
+cache:
+  directories:
+  - $TRAVIS_BUILD_DIR/resources
 
 before_script:
-  - mkdir resources
+  - .travis-scripts/cache-browscap.sh
   - travis_retry composer self-update
-  - if [ "`phpenv version-name`" == "5.3" ] || [ "`phpenv version-name`" == "5.4" ]; then wget http://browscap.org/stream?q=Full_PHP_BrowsCapINI -O ./resources/full_php_browscap.ini; fi
-  - if [ "`phpenv version-name`" != "5.3" ] && [ "`phpenv version-name`" != "5.4" ]; then travis_retry composer require --no-update --prefer-source browscap/browscap:dev-master; fi
   - travis_retry composer install -o --prefer-source
-  - if [ "`phpenv version-name`" != "5.3" ] && [ "`phpenv version-name`" != "5.4" ]; then php vendor/browscap/browscap/bin/browscap build --output ../../../resources/ test; fi
 
 script:
-  - php -d zend.enable_gc=0 -d browscap=./resources/full_php_browscap.ini vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover --colors --verbose
+  - php -d zend.enable_gc=0 -d browscap=$TRAVIS_BUILD_DIR/resources/browscap.ini vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover --colors --verbose
 
 after_script:
-  - rm -rf resources
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a userland replacement for PHP's native `get_browser()` function, which 
 
 Forked from https://github.com/GaretJax/phpbrowscap.
 
-[![Build Status](https://secure.travis-ci.org/browscap/browscap-php.png?branch=master)](http://travis-ci.org/browsecap/browscap-php) [![Code Coverage](https://scrutinizer-ci.com/g/browscap/browscap-php/badges/coverage.png?s=61cb32ca83d2053ed9b140690b6e18dfa00e4639)](https://scrutinizer-ci.com/g/browscap/browscap-php/) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/browscap/browscap-php/badges/quality-score.png?s=db1cc1699b1cb6ac6ae46754ef9612217eba5526)](https://scrutinizer-ci.com/g/browscap/browscap-php/)
+[![Build Status](https://secure.travis-ci.org/browscap/browscap-php.png?branch=2.x)](http://travis-ci.org/browsecap/browscap-php) [![Code Coverage](https://scrutinizer-ci.com/g/browscap/browscap-php/badges/coverage.png?s=61cb32ca83d2053ed9b140690b6e18dfa00e4639)](https://scrutinizer-ci.com/g/browscap/browscap-php/) [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/browscap/browscap-php/badges/quality-score.png?s=db1cc1699b1cb6ac6ae46754ef9612217eba5526)](https://scrutinizer-ci.com/g/browscap/browscap-php/)
 
 Installation
 ------------


### PR DESCRIPTION
Use the browscap.ini caching mentioned in #99 but on the 2.x branch (5.3 and 5.4 are also no longer allowed to fail)