### PR TITLE
Use interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ before_script:
   - travis_retry composer install -o --prefer-source
 
 script:
-# xdebug is not installed on hhvm, so we are skipping the creation of code coverage data there
-  - if [ "`phpenv version-name`" != "hhvm" ]; then php -d browscap=$TRAVIS_BUILD_DIR/resources/browscap.ini vendor/bin/phpunit --colors --verbose --exclude-group compare --coverage-text --coverage-clover=coverage.clover; fi
-  - if [ "`phpenv version-name`" == "hhvm" ]; then php -d browscap=$TRAVIS_BUILD_DIR/resources/browscap.ini vendor/bin/phpunit --colors --verbose --exclude-group compare; fi
+# xdebug is not installed on hhvm and php7, so we are skipping the creation of code coverage data there
+  - if [ "`phpenv version-name`" == "5.5" ] || [ "`phpenv version-name`" == "5.6" ]; then php -d browscap=$TRAVIS_BUILD_DIR/resources/browscap.ini vendor/bin/phpunit --colors --verbose --exclude-group compare --coverage-text --coverage-clover=coverage.clover; fi
+  - if [ "`phpenv version-name`" != "5.5" ] && [ "`phpenv version-name`" != "5.6" ]; then php -d browscap=$TRAVIS_BUILD_DIR/resources/browscap.ini vendor/bin/phpunit --colors --verbose --exclude-group compare; fi
   - php -d browscap=$TRAVIS_BUILD_DIR/resources/browscap.ini vendor/bin/phpunit --colors --verbose --group compare
   - php vendor/bin/phpcs --standard=psr2 -pn src tests
 
 after_script:
-# xdebug is not installed on hhvm, so we have no code coverage data to send
-  - if [ "`phpenv version-name`" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "`phpenv version-name`" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+# xdebug is not installed on hhvm and php7, so we have no code coverage data to send
+  - if [ "`phpenv version-name`" == "5.5" ] || [ "`phpenv version-name`" == "5.6" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "`phpenv version-name`" == "5.5" ] || [ "`phpenv version-name`" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 

--- a/src/Cache/BrowscapCache.php
+++ b/src/Cache/BrowscapCache.php
@@ -116,11 +116,19 @@ class BrowscapCache implements BrowscapCacheInterface
         $success = null;
         $data    = $this->cache->getItem($cacheId, $success);
 
+        if (!$success) {
+            $success = false;
+
+            return null;
+        }
+
         if (!isset($data['content'])) {
             $success = false;
 
             return null;
         }
+
+        $success = true;
 
         return unserialize($data['content']);
     }

--- a/src/Cache/BrowscapCacheInterface.php
+++ b/src/Cache/BrowscapCacheInterface.php
@@ -43,21 +43,14 @@ use WurflCache\Adapter\AdapterInterface;
  * @license    http://www.opensource.org/licenses/MIT MIT License
  * @link       https://github.com/browscap/browscap-php/
  */
-class BrowscapCache implements BrowscapCacheInterface
+interface BrowscapCacheInterface
 {
     /**
-     * Path to the cache directory
+     * The cache livetime in seconds.
      *
-     * @var \WurflCache\Adapter\AdapterInterface
+     * @var integer
      */
-    private $cache = null;
-
-    /**
-     * Detected browscap version (read from INI file)
-     *
-     * @var int
-     */
-    private $version = null;
+    const CACHE_LIVETIME = 315360000; // ~10 years (60 * 60 * 24 * 365 * 10)
 
     /**
      * Constructor class, checks for the existence of (and loads) the cache and
@@ -66,31 +59,14 @@ class BrowscapCache implements BrowscapCacheInterface
      * @param \WurflCache\Adapter\AdapterInterface $adapter
      * @param int                                  $updateInterval
      */
-    public function __construct(AdapterInterface $adapter, $updateInterval = BrowscapCacheInterface::CACHE_LIVETIME)
-    {
-        $this->cache = $adapter;
-        $this->cache->setExpiration((int) $updateInterval);
-    }
+    public function __construct(AdapterInterface $adapter, $updateInterval = self::CACHE_LIVETIME);
 
     /**
      * Gets the version of the Browscap data
      *
      * @return int
      */
-    public function getVersion()
-    {
-        if ($this->version === null) {
-            $success = true;
-
-            $version = $this->getItem('browscap.version', false, $success);
-
-            if ($version !== null && $success) {
-                $this->version = (int) $version;
-            }
-        }
-
-        return $this->version;
-    }
+    public function getVersion();
 
     /**
      * Get an item.
@@ -101,29 +77,7 @@ class BrowscapCache implements BrowscapCacheInterface
      *
      * @return mixed Data on success, null on failure
      */
-    public function getItem($cacheId, $withVersion = true, & $success = null)
-    {
-        if ($withVersion) {
-            $cacheId .= '.'.$this->getVersion();
-        }
-
-        if (!$this->cache->hasItem($cacheId)) {
-            $success = false;
-
-            return null;
-        }
-
-        $success = null;
-        $data    = $this->cache->getItem($cacheId, $success);
-
-        if (!isset($data['content'])) {
-            $success = false;
-
-            return null;
-        }
-
-        return unserialize($data['content']);
-    }
+    public function getItem($cacheId, $withVersion = true, & $success = null);
 
     /**
      * save the content into an php file
@@ -134,20 +88,7 @@ class BrowscapCache implements BrowscapCacheInterface
      *
      * @return boolean whether the file was correctly written to the disk
      */
-    public function setItem($cacheId, $content, $withVersion = true)
-    {
-        // Get the whole PHP code
-        $data = array(
-            'content' => serialize($content),
-        );
-
-        if ($withVersion) {
-            $cacheId .= '.'.$this->getVersion();
-        }
-
-        // Save and return
-        return $this->cache->setItem($cacheId, $data);
-    }
+    public function setItem($cacheId, $content, $withVersion = true);
 
     /**
      * Test if an item exists.
@@ -157,14 +98,7 @@ class BrowscapCache implements BrowscapCacheInterface
      *
      * @return bool
      */
-    public function hasItem($cacheId, $withVersion = true)
-    {
-        if ($withVersion) {
-            $cacheId .= '.'.$this->getVersion();
-        }
-
-        return $this->cache->hasItem($cacheId);
-    }
+    public function hasItem($cacheId, $withVersion = true);
 
     /**
      * Remove an item.
@@ -174,22 +108,12 @@ class BrowscapCache implements BrowscapCacheInterface
      *
      * @return bool
      */
-    public function removeItem($cacheId, $withVersion = true)
-    {
-        if ($withVersion) {
-            $cacheId .= '.'.$this->getVersion();
-        }
-
-        return $this->cache->removeItem($cacheId);
-    }
+    public function removeItem($cacheId, $withVersion = true);
 
     /**
      * Flush the whole storage
      *
      * @return bool
      */
-    public function flush()
-    {
-        return $this->cache->flush();
-    }
+    public function flush();
 }

--- a/src/Command/ConvertCommand.php
+++ b/src/Command/ConvertCommand.php
@@ -31,7 +31,7 @@
 namespace BrowscapPHP\Command;
 
 use BrowscapPHP\Browscap;
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use BrowscapPHP\Helper\LoggerHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -54,7 +54,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ConvertCommand extends Command
 {
     /**
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
@@ -64,10 +64,10 @@ class ConvertCommand extends Command
     private $defaultIniFile;
 
     /**
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
-     * @param string                           $defaultIniFile
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
+     * @param string                                    $defaultIniFile
      */
-    public function __construct(BrowscapCache $cache, $defaultIniFile)
+    public function __construct(BrowscapCacheInterface $cache, $defaultIniFile)
     {
         parent::__construct();
 

--- a/src/Command/LogfileCommand.php
+++ b/src/Command/LogfileCommand.php
@@ -31,7 +31,7 @@
 namespace BrowscapPHP\Command;
 
 use BrowscapPHP\Browscap;
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use BrowscapPHP\Exception\InvalidArgumentException;
 use BrowscapPHP\Exception\ReaderException;
 use BrowscapPHP\Exception\UnknownBrowserException;
@@ -68,7 +68,7 @@ use Symfony\Component\Finder\SplFileInfo;
 class LogfileCommand extends Command
 {
     /**
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
@@ -85,9 +85,9 @@ class LogfileCommand extends Command
     private $totalCount = 0;
 
     /**
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
      */
-    public function __construct(BrowscapCache $cache)
+    public function __construct(BrowscapCacheInterface $cache)
     {
         parent::__construct();
 
@@ -268,9 +268,11 @@ class LogfileCommand extends Command
             // do nothing
         }
 
+        $outputFile = $input->getArgument('output').'/output.txt';
+
         try {
             $fs->dumpFile(
-                $input->getArgument('output').'/output.txt',
+                $outputFile,
                 implode(PHP_EOL, array_unique($this->undefinedClients))
             );
         } catch (IOException $e) {
@@ -373,6 +375,8 @@ class LogfileCommand extends Command
      */
     private function handleLine(OutputInterface $output, ReaderCollection $collection, Browscap $browscap, $line)
     {
+        $userAgentString = '';
+
         try {
             $userAgentString = $collection->read($line);
 

--- a/src/Command/ParserCommand.php
+++ b/src/Command/ParserCommand.php
@@ -31,7 +31,7 @@
 namespace BrowscapPHP\Command;
 
 use BrowscapPHP\Browscap;
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use BrowscapPHP\Helper\LoggerHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -54,14 +54,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ParserCommand extends Command
 {
     /**
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
     /**
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
      */
-    public function __construct(BrowscapCache $cache)
+    public function __construct(BrowscapCacheInterface $cache)
     {
         parent::__construct();
 

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -31,7 +31,7 @@
 namespace BrowscapPHP\Command;
 
 use BrowscapPHP\Browscap;
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use BrowscapPHP\Helper\IniLoader;
 use BrowscapPHP\Helper\LoggerHelper;
 use Symfony\Component\Console\Command\Command;
@@ -55,14 +55,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 class UpdateCommand extends Command
 {
     /**
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
     /**
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
      */
-    public function __construct(BrowscapCache $cache)
+    public function __construct(BrowscapCacheInterface $cache)
     {
         parent::__construct();
 

--- a/src/Helper/Converter.php
+++ b/src/Helper/Converter.php
@@ -30,10 +30,9 @@
 
 namespace BrowscapPHP\Helper;
 
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use BrowscapPHP\Exception\FileNotFoundException;
 use BrowscapPHP\IniParser\IniParser;
-use BrowscapPHP\Parser\Ini;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -72,7 +71,7 @@ class Converter
     /**
      * The cache instance
      *
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
@@ -93,10 +92,10 @@ class Converter
     /**
      * class constructor
      *
-     * @param \Psr\Log\LoggerInterface         $logger
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
+     * @param \Psr\Log\LoggerInterface                  $logger
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
      */
-    public function __construct(LoggerInterface $logger, BrowscapCache $cache)
+    public function __construct(LoggerInterface $logger, BrowscapCacheInterface $cache)
     {
         $this->logger = $logger;
         $this->cache  = $cache;

--- a/src/Parser/Helper/GetData.php
+++ b/src/Parser/Helper/GetData.php
@@ -30,7 +30,7 @@
 
 namespace BrowscapPHP\Parser\Helper;
 
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use BrowscapPHP\Data\PropertyFormatter;
 use BrowscapPHP\Data\PropertyHolder;
 use Psr\Log\LoggerInterface;
@@ -53,7 +53,7 @@ class GetData implements GetDataInterface
     /**
      * The cache instance
      *
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
@@ -72,11 +72,11 @@ class GetData implements GetDataInterface
     /**
      * class contsructor
      *
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
-     * @param \Psr\Log\LoggerInterface         $logger
-     * @param \BrowscapPHP\Helper\Quoter       $quoter
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
+     * @param \Psr\Log\LoggerInterface                  $logger
+     * @param \BrowscapPHP\Helper\Quoter                $quoter
      */
-    public function __construct(BrowscapCache $cache, LoggerInterface $logger, Quoter $quoter)
+    public function __construct(BrowscapCacheInterface $cache, LoggerInterface $logger, Quoter $quoter)
     {
         $this->cache  = $cache;
         $this->logger = $logger;

--- a/src/Parser/Helper/GetDataInterface.php
+++ b/src/Parser/Helper/GetDataInterface.php
@@ -30,7 +30,7 @@
 
 namespace BrowscapPHP\Parser\Helper;
 
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use Psr\Log\LoggerInterface;
 use BrowscapPHP\Helper\Quoter;
 
@@ -51,11 +51,11 @@ interface GetDataInterface
     /**
      * class contsructor
      *
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
-     * @param \Psr\Log\LoggerInterface         $logger
-     * @param \BrowscapPHP\Helper\Quoter       $quoter
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
+     * @param \Psr\Log\LoggerInterface                  $logger
+     * @param \BrowscapPHP\Helper\Quoter                $quoter
      */
-    public function __construct(BrowscapCache $cache, LoggerInterface $logger, Quoter $quoter);
+    public function __construct(BrowscapCacheInterface $cache, LoggerInterface $logger, Quoter $quoter);
 
     /**
      * Gets the settings for a given pattern (method calls itself to

--- a/src/Parser/Helper/GetPattern.php
+++ b/src/Parser/Helper/GetPattern.php
@@ -30,7 +30,7 @@
 
 namespace BrowscapPHP\Parser\Helper;
 
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -50,7 +50,7 @@ class GetPattern implements GetPatternInterface
     /**
      * The cache instance
      *
-     * @var \BrowscapPHP\Cache\BrowscapCache
+     * @var \BrowscapPHP\Cache\BrowscapCacheInterface
      */
     private $cache = null;
 
@@ -64,10 +64,10 @@ class GetPattern implements GetPatternInterface
     /**
      * class contructor
      *
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
-     * @param \Psr\Log\LoggerInterface         $logger
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
+     * @param \Psr\Log\LoggerInterface                  $logger
      */
-    public function __construct(BrowscapCache $cache, LoggerInterface $logger)
+    public function __construct(BrowscapCacheInterface $cache, LoggerInterface $logger)
     {
         $this->cache  = $cache;
         $this->logger = $logger;

--- a/src/Parser/Helper/GetPatternInterface.php
+++ b/src/Parser/Helper/GetPatternInterface.php
@@ -30,7 +30,7 @@
 
 namespace BrowscapPHP\Parser\Helper;
 
-use BrowscapPHP\Cache\BrowscapCache;
+use BrowscapPHP\Cache\BrowscapCacheInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -50,10 +50,10 @@ interface GetPatternInterface
     /**
      * class contructor
      *
-     * @param \BrowscapPHP\Cache\BrowscapCache $cache
-     * @param \Psr\Log\LoggerInterface         $logger
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface $cache
+     * @param \Psr\Log\LoggerInterface                  $logger
      */
-    public function __construct(BrowscapCache $cache, LoggerInterface $logger);
+    public function __construct(BrowscapCacheInterface $cache, LoggerInterface $logger);
 
     /**
      * Gets some possible patterns that have to be matched against the user agent. With the given

--- a/tests/BrowscapTest.php
+++ b/tests/BrowscapTest.php
@@ -103,7 +103,7 @@ class BrowscapTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \BrowscapPHP\Exception
-     * @expectedExceptionMessage the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCache or an instanceof of \WurflCache\Adapter\AdapterInterface
+     * @expectedExceptionMessage the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or an instanceof of \WurflCache\Adapter\AdapterInterface
      */
     public function testSetGetCacheWithWrongType()
     {


### PR DESCRIPTION
For my other project (mimmi20/browscap-json-generator) I want to use Json files as cache for browscap-php. 

To make this easier to handle, browscap-php should offer an interface for the required cache. All classes where the cache is needed, should only rely on this interface. 