### PR TITLE
[3.x] extend timeout

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,7 @@
 inherit: true
 
 tools:
-    external_code_coverage: true
+    external_code_coverage:
+        enabled: true
+        timeout: 1800 # 30 minutes
+        runs: 1


### PR DESCRIPTION
To prevent error from scrutinizer caused by timeouts, the timeout should be extended. 