### PR TITLE
make cache option optional

### DIFF
--- a/src/Command/CheckUpdateCommand.php
+++ b/src/Command/CheckUpdateCommand.php
@@ -71,9 +71,9 @@ class CheckUpdateCommand extends Command
      */
     public function __construct($defaultCacheFolder)
     {
-        parent::__construct();
-
         $this->defaultCacheFolder = $defaultCacheFolder;
+
+        parent::__construct();
     }
 
     /**
@@ -113,7 +113,7 @@ class CheckUpdateCommand extends Command
             ->addOption(
                 'cache',
                 'c',
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'Where the cache files are located',
                 $this->defaultCacheFolder
             )

--- a/src/Command/ConvertCommand.php
+++ b/src/Command/ConvertCommand.php
@@ -76,10 +76,10 @@ class ConvertCommand extends Command
      */
     public function __construct($defaultCacheFolder, $defaultIniFile)
     {
-        parent::__construct();
-
         $this->defaultCacheFolder = $defaultCacheFolder;
         $this->defaultIniFile     = $defaultIniFile;
+
+        parent::__construct();
     }
 
     /**
@@ -123,7 +123,7 @@ class ConvertCommand extends Command
             ->addOption(
                 'cache',
                 'c',
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'Where the cache files are located',
                 $this->defaultCacheFolder
             )

--- a/src/Command/FetchCommand.php
+++ b/src/Command/FetchCommand.php
@@ -63,9 +63,9 @@ class FetchCommand extends Command
      */
     public function __construct($defaultIniFile)
     {
-        parent::__construct();
-
         $this->defaultIniFile = $defaultIniFile;
+
+        parent::__construct();
     }
 
     /**

--- a/src/Command/LogfileCommand.php
+++ b/src/Command/LogfileCommand.php
@@ -96,9 +96,9 @@ class LogfileCommand extends Command
      */
     public function __construct($defaultCacheFolder)
     {
-        parent::__construct();
-
         $this->defaultCacheFolder = $defaultCacheFolder;
+
+        parent::__construct();
     }
 
     /**
@@ -162,7 +162,7 @@ class LogfileCommand extends Command
             ->addOption(
                 'cache',
                 'c',
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'Where the cache files are located',
                 $this->defaultCacheFolder
             )

--- a/src/Command/ParserCommand.php
+++ b/src/Command/ParserCommand.php
@@ -70,9 +70,9 @@ class ParserCommand extends Command
      */
     public function __construct($defaultCacheFolder)
     {
-        parent::__construct();
-
         $this->defaultCacheFolder = $defaultCacheFolder;
+
+        parent::__construct();
     }
 
     /**
@@ -110,7 +110,7 @@ class ParserCommand extends Command
             ->addOption(
                 'cache',
                 'c',
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'Where the cache files are located',
                 $this->defaultCacheFolder
             )

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -71,9 +71,9 @@ class UpdateCommand extends Command
      */
     public function __construct($defaultCacheFolder)
     {
-        parent::__construct();
-
         $this->defaultCacheFolder = $defaultCacheFolder;
+
+        parent::__construct();
     }
 
     /**
@@ -119,7 +119,7 @@ class UpdateCommand extends Command
             ->addOption(
                 'cache',
                 'c',
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_OPTIONAL,
                 'Where the cache files are located',
                 $this->defaultCacheFolder
             )


### PR DESCRIPTION
I made the new cache option a required one, but I wanted to make that option optional. I also discovered that the options we set in the command constructor were not available in the `configure` function.