### PR TITLE
Switch from WurflCache to Symfony Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ What's changed in version 3.x
 
 * the namespace was changed to `BrowscapPHP` 
 * the `Browscap` class was split into pieces
-  * for caching the [WurflCache](https://github.com/mimmi20/WurflCache) package is used
+  * for caching the [Symfony/Cache](https://github.com/symfony/cache) package is used
   * for downloading the browscap.ini the [Guzzle HTTP](https://github.com/guzzle/guzzle) package is used
 
 ## Removed features
@@ -64,7 +64,7 @@ What's changed in version 3.x
 
 ## New features
 
-* now it is possible to use other caches than the file cache (see the [WurflCache](https://github.com/mimmi20/WurflCache) package formore information)
+* now it is possible to use other caches than the file cache (see the [Symfony/Cache](https://github.com/symfony/cache) package for more information)
 * now it is possible to write your own formatter to change the output format 
 * now it is possbile to set a PSR-3 compatible logger
 
@@ -83,7 +83,7 @@ $result = $bc->getBrowser();
 Change this to the base setup for version 3.x. to use the v2 cache directory
 ```php
 $bc = new \BrowscapPHP\Browscap();
-$adapter = new \WurflCache\Adapter\File([\WurflCache\Adapter\File::DIR => $cacheDir]);
+$adapter = new \Symfony\Component\Cache\Simple\FilesystemCache('', 0, $cacheDir); 
 $bc->setCache($adapter);
 $result = $bc->getBrowser();
 ```
@@ -104,25 +104,6 @@ $bc = new \BrowscapPHP\Browscap();
 $logger = new \Monolog\Logger('name');
 $bc->setLogger($logger);
 ```
-
-## Setting up a Memcache
-
-If you don't want to use a file cache, you may change the cache adapter. 
-This cache adapter has to implement the adapter interface from WurflCache\Adapter\AdapterInterface
-```php
-$memcacheConfiguration = [
-    'host'             => '127.0.0.1', // optional, defaults to '127.0.0.1'
-    'port'             => 11211,       // optional, defaults to 11211
-    'namespace'        => 'wurfl',     // optional, defaults to 'wurfl'
-    'cacheExpiration'  => 0,           // optional, defaults to 0 (cache does not expire), expiration time in seconds
-    'cacheVersion'     => '1234',      // optional, default value may change in external library
-];
-$adapter = new \WurflCache\Adapter\Memcached($memcacheConfiguration);
-$bc = new \BrowscapPHP\Browscap();
-$bc->setCache($adapter);
-```
-
-NOTE: Please look into the [WurflCache](https://github.com/mimmi20/WurflCache) package for infomation about the other cache adapters.
 
 ## Using the full browscap.ini file
 

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "grimsonmarc/browscap-php",
+    "name": "browscap/browscap-php",
     "type": "library",
     "description": "Standalone replacement for php's native get_browser() function",
     "keywords": ["get_browser", "browser", "capabilities", "user agent"],
-    "homepage": "https://github.com/grimsonmarc/browscap-php",
+    "homepage": "https://github.com/browscap/browscap-php",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "browscap/browscap-php",
+    "name": "grimsonmarc/browscap-php",
     "type": "library",
     "description": "Standalone replacement for php's native get_browser() function",
     "keywords": ["get_browser", "browser", "capabilities", "user agent"],
-    "homepage": "https://github.com/browscap/browscap-php",
+    "homepage": "https://github.com/grimsonmarc/browscap-php",
     "license": "MIT",
     "authors": [
         {
@@ -17,6 +17,10 @@
         {
             "name": "Thomas Mueller",
             "email": "t_mueller_stolzenhain@yahoo.de"
+        },
+        {
+            "name": "Marc Grimson",
+            "email": "grimson.marc@gmail.com"
         }
     ],
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,13 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "mimmi20/wurflcache": "^1.3",
         "guzzlehttp/guzzle": "^6.2",
         "symfony/filesystem": "^2.6 || ^3.0",
         "symfony/finder": "^2.6 || ^3.0",
         "symfony/console": "^2.6 || ^3.0",
-        "monolog/monolog": "^1.7"
+        "symfony/cache": "3.3.x-dev",
+        "monolog/monolog": "^1.7",
+        "psr/simple-cache": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.3",

--- a/src/Browscap.php
+++ b/src/Browscap.php
@@ -34,8 +34,8 @@ use BrowscapPHP\Helper\Quoter;
 use BrowscapPHP\Parser\ParserInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use WurflCache\Adapter\AdapterInterface;
-use WurflCache\Adapter\File;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -80,7 +80,7 @@ class Browscap
     private $logger = null;
 
     /**
-     * Set theformatter instance to use for the getBrowser() result
+     * Set the formatter instance to use for the getBrowser() result
      *
      * @param \BrowscapPHP\Formatter\FormatterInterface $formatter
      *
@@ -115,9 +115,7 @@ class Browscap
         if (null === $this->cache) {
             $cacheDirectory = __DIR__ . '/../resources/';
 
-            $cacheAdapter = new File(
-                [File::DIR => $cacheDirectory]
-            );
+            $cacheAdapter = new FilesystemCache('', 0, $cacheDirectory);
 
             $this->cache = new BrowscapCache($cacheAdapter);
         }
@@ -128,7 +126,7 @@ class Browscap
     /**
      * Sets a cache instance
      *
-     * @param \BrowscapPHP\Cache\BrowscapCacheInterface|\WurflCache\Adapter\AdapterInterface $cache
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface|\Psr\SimpleCache\CacheInterface $cache
      *
      * @throws \BrowscapPHP\Exception
      * @return \BrowscapPHP\Browscap
@@ -137,12 +135,12 @@ class Browscap
     {
         if ($cache instanceof BrowscapCacheInterface) {
             $this->cache = $cache;
-        } elseif ($cache instanceof AdapterInterface) {
+        } elseif ($cache instanceof CacheInterface) {
             $this->cache = new BrowscapCache($cache);
         } else {
             throw new Exception(
                 'the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or '
-                . 'an instanceof of \WurflCache\Adapter\AdapterInterface',
+                . 'an instanceof of \Psr\SimpleCache\CacheInterface',
                 Exception::CACHE_INCOMPATIBLE
             );
         }

--- a/src/BrowscapUpdater.php
+++ b/src/BrowscapUpdater.php
@@ -37,8 +37,8 @@ use BrowscapPHP\Helper\IniLoader;
 use GuzzleHttp\Client;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use WurflCache\Adapter\AdapterInterface;
-use WurflCache\Adapter\File;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -90,9 +90,7 @@ class BrowscapUpdater
         if (null === $this->cache) {
             $cacheDirectory = __DIR__ . '/../resources/';
 
-            $cacheAdapter = new File(
-                [File::DIR => $cacheDirectory]
-            );
+            $cacheAdapter = new FilesystemCache('', 0, $cacheDirectory);
 
             $this->cache = new BrowscapCache($cacheAdapter);
         }
@@ -103,7 +101,7 @@ class BrowscapUpdater
     /**
      * Sets a cache instance
      *
-     * @param \BrowscapPHP\Cache\BrowscapCacheInterface|\WurflCache\Adapter\AdapterInterface $cache
+     * @param \BrowscapPHP\Cache\BrowscapCacheInterface|\Psr\SimpleCache\CacheInterface $cache
      *
      * @throws \BrowscapPHP\Exception
      *
@@ -113,12 +111,12 @@ class BrowscapUpdater
     {
         if ($cache instanceof BrowscapCacheInterface) {
             $this->cache = $cache;
-        } elseif ($cache instanceof AdapterInterface) {
+        } elseif ($cache instanceof CacheInterface) {
             $this->cache = new BrowscapCache($cache);
         } else {
             throw new Exception(
                 'the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or '
-                . 'an instanceof of \WurflCache\Adapter\AdapterInterface',
+                . 'an instanceof of \Psr\SimpleCache\CacheInterface',
                 Exception::CACHE_INCOMPATIBLE
             );
         }

--- a/src/Cache/BrowscapCache.php
+++ b/src/Cache/BrowscapCache.php
@@ -29,10 +29,10 @@
 
 namespace BrowscapPHP\Cache;
 
-use WurflCache\Adapter\AdapterInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
- * a cache proxy to be able to use the cache adapters provided by the WurflCache package
+ * a cache proxy to be able to use the cache adapters that implement the PSR-16 SimpleCache Cache interface
  *
  * @category   Browscap-PHP
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
@@ -46,7 +46,7 @@ class BrowscapCache implements BrowscapCacheInterface
     /**
      * Path to the cache directory
      *
-     * @var \WurflCache\Adapter\AdapterInterface
+     * @var \Psr\SimpleCache\CacheInterface
      */
     private $cache = null;
 
@@ -75,9 +75,9 @@ class BrowscapCache implements BrowscapCacheInterface
      * Constructor class, checks for the existence of (and loads) the cache and
      * if needed updated the definitions
      *
-     * @param \WurflCache\Adapter\AdapterInterface $adapter
+     * @param \Psr\SimpleCache\CacheInterface $adapter
      */
-    public function __construct(AdapterInterface $adapter)
+    public function __construct(CacheInterface $adapter)
     {
         $this->cache = $adapter;
     }
@@ -157,16 +157,15 @@ class BrowscapCache implements BrowscapCacheInterface
             $cacheId .= '.' . $this->getVersion();
         }
 
-        if (!$this->cache->hasItem($cacheId)) {
+        if (!$this->cache->has($cacheId)) {
             $success = false;
 
             return null;
         }
 
-        $success = null;
-        $data    = $this->cache->getItem($cacheId, $success);
+        $data = $this->cache->get($cacheId);
 
-        if (!$success) {
+        if (null === $data) {
             $success = false;
 
             return null;
@@ -204,7 +203,7 @@ class BrowscapCache implements BrowscapCacheInterface
         }
 
         // Save and return
-        return $this->cache->setItem($cacheId, $data);
+        return $this->cache->set($cacheId, $data);
     }
 
     /**
@@ -221,7 +220,7 @@ class BrowscapCache implements BrowscapCacheInterface
             $cacheId .= '.' . $this->getVersion();
         }
 
-        return $this->cache->hasItem($cacheId);
+        return $this->cache->has($cacheId);
     }
 
     /**
@@ -238,7 +237,7 @@ class BrowscapCache implements BrowscapCacheInterface
             $cacheId .= '.' . $this->getVersion();
         }
 
-        return $this->cache->removeItem($cacheId);
+        return $this->cache->delete($cacheId);
     }
 
     /**
@@ -248,6 +247,6 @@ class BrowscapCache implements BrowscapCacheInterface
      */
     public function flush()
     {
-        return $this->cache->flush();
+        return $this->cache->clear();
     }
 }

--- a/src/Cache/BrowscapCacheInterface.php
+++ b/src/Cache/BrowscapCacheInterface.php
@@ -29,10 +29,10 @@
 
 namespace BrowscapPHP\Cache;
 
-use WurflCache\Adapter\AdapterInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
- * a cache proxy to be able to use the cache adapters provided by the WurflCache package
+ * a cache proxy to be able to use the cache adapters that implement the PSR-16 SimpleCache Cache interface
  *
  * @category   Browscap-PHP
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
@@ -54,9 +54,9 @@ interface BrowscapCacheInterface
      * Constructor class, checks for the existence of (and loads) the cache and
      * if needed updated the definitions
      *
-     * @param \WurflCache\Adapter\AdapterInterface $adapter
+     * @param \Psr\SimpleCache\CacheInterface $cache
      */
-    public function __construct(AdapterInterface $adapter);
+    public function __construct(CacheInterface $adapter);
 
     /**
      * Gets the version of the Browscap data

--- a/src/Command/CheckUpdateCommand.php
+++ b/src/Command/CheckUpdateCommand.php
@@ -37,7 +37,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use WurflCache\Adapter\File;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
  * command to fetch a browscap ini file from the remote host, convert it into an array and store the content in a local
@@ -138,7 +138,7 @@ class CheckUpdateCommand extends Command
     private function getCache(InputInterface $input)
     {
         if (null === $this->cache) {
-            $cacheAdapter = new File([File::DIR => $input->getOption('cache')]);
+            $cacheAdapter = new FilesystemCache('', 0, $input->getOption('cache'));
             $this->cache  = new BrowscapCache($cacheAdapter);
         }
 

--- a/src/Command/ConvertCommand.php
+++ b/src/Command/ConvertCommand.php
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use WurflCache\Adapter\File;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
  * command to convert a downloaded Browscap ini file and write it to the cache
@@ -156,7 +156,7 @@ class ConvertCommand extends Command
     private function getCache(InputInterface $input)
     {
         if (null === $this->cache) {
-            $cacheAdapter = new File([File::DIR => $input->getOption('cache')]);
+            $cacheAdapter = new FilesystemCache('', 0, $input->getOption('cache'));
             $this->cache  = new BrowscapCache($cacheAdapter);
         }
 

--- a/src/Command/LogfileCommand.php
+++ b/src/Command/LogfileCommand.php
@@ -51,7 +51,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
-use WurflCache\Adapter\File;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
  * commands to parse a log file and parse the useragents in it
@@ -518,7 +518,7 @@ class LogfileCommand extends Command
     private function getCache(InputInterface $input)
     {
         if (null === $this->cache) {
-            $cacheAdapter = new File([File::DIR => $input->getOption('cache')]);
+            $cacheAdapter = new FilesystemCache('', 0, $input->getOption('cache'));
             $this->cache  = new BrowscapCache($cacheAdapter);
         }
 

--- a/src/Command/ParserCommand.php
+++ b/src/Command/ParserCommand.php
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use WurflCache\Adapter\File;
+use Symfony\Component\Cache\Simple\FilesystemCache; 
 
 /**
  * commands to parse a given useragent
@@ -149,7 +149,7 @@ class ParserCommand extends Command
     private function getCache(InputInterface $input)
     {
         if (null === $this->cache) {
-            $cacheAdapter = new File([File::DIR => $input->getOption('cache')]);
+            $cacheAdapter = new FilesystemCache('', 0, $input->getOption('cache'));
             $this->cache  = new BrowscapCache($cacheAdapter);
         }
 

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -38,7 +38,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use WurflCache\Adapter\File;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 /**
  * command to fetch a browscap ini file from the remote host, convert it into an array and store the content in a local
@@ -153,7 +153,7 @@ class UpdateCommand extends Command
     private function getCache(InputInterface $input)
     {
         if (null === $this->cache) {
-            $cacheAdapter = new File([File::DIR => $input->getOption('cache')]);
+            $cacheAdapter = new FilesystemCache('', 0, $input->getOption('cache'));
             $this->cache  = new BrowscapCache($cacheAdapter);
         }
 

--- a/tests/BrowscapTest.php
+++ b/tests/BrowscapTest.php
@@ -95,8 +95,8 @@ class BrowscapTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetCacheWithAdapter()
     {
-        /** @var \WurflCache\Adapter\Memory $cache */
-        $cache = $this->getMockBuilder(\WurflCache\Adapter\Memory::class)
+        /** @var \Symfony\Component\Cache\Simple\ArrayCache $cache */ 
+        $cache = $this->getMockBuilder(\Symfony\Component\Cache\Simple\ArrayCache::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -106,7 +106,7 @@ class BrowscapTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \BrowscapPHP\Exception
-     * @expectedExceptionMessage the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or an instanceof of \WurflCache\Adapter\AdapterInterface
+     * @expectedExceptionMessage the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or an instanceof of \Psr\SimpleCache\CacheInterface 
      */
     public function testSetGetCacheWithWrongType()
     {

--- a/tests/BrowscapUpdaterTest.php
+++ b/tests/BrowscapUpdaterTest.php
@@ -6,7 +6,7 @@ use BrowscapPHP\BrowscapUpdater;
 use BrowscapPHP\Helper\Exception;
 use BrowscapPHP\Helper\IniLoader;
 use org\bovigo\vfs\vfsStream;
-use WurflCache\Adapter\Memory;
+use Symfony\Component\Cache\Simple\ArrayCache;
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -85,8 +85,8 @@ class BrowscapUpdaterTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetGetCacheWithAdapter()
     {
-        /** @var \WurflCache\Adapter\Memory $cache */
-        $cache = $this->getMockBuilder(\WurflCache\Adapter\Memory::class)
+        /** @var \Symfony\Component\Cache\Simple\ArrayCache $cache */
+        $cache = $this->getMockBuilder(\Symfony\Component\Cache\Simple\ArrayCache::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -96,7 +96,7 @@ class BrowscapUpdaterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \BrowscapPHP\Exception
-     * @expectedExceptionMessage the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or an instanceof of \WurflCache\Adapter\AdapterInterface
+     * @expectedExceptionMessage the cache has to be an instance of \BrowscapPHP\Cache\BrowscapCacheInterface or an instanceof of \Psr\SimpleCache\CacheInterface
      */
     public function testSetGetCacheWithWrongType()
     {
@@ -298,7 +298,7 @@ AolVersion=0
 
         vfsStream::setup(self::STORAGE_DIR, null, $structure);
 
-        $cache = new Memory();
+        $cache = new ArrayCache();
         $this->object->setCache($cache);
 
         $this->object->convertFile(vfsStream::url(self::STORAGE_DIR . DIRECTORY_SEPARATOR . 'test.ini'));
@@ -416,7 +416,7 @@ CssVersion=0
 AolVersion=0
 ';
 
-        $cache = new Memory();
+        $cache = new ArrayCache();
         $this->object->setCache($cache);
 
         $this->object->convertString($content);

--- a/tests/Cache/BrowscapCacheTest.php
+++ b/tests/Cache/BrowscapCacheTest.php
@@ -4,14 +4,14 @@ namespace BrowscapPHPTest\Command;
 
 use BrowscapPHP\Cache\BrowscapCache;
 use PHPUnit_Framework_TestCase;
-use WurflCache\Adapter\Memory;
-use WurflCache\Adapter\NullStorage;
+use Symfony\Component\Cache\Simple\ArrayCache;
+use Symfony\Component\Cache\Simple\NullCache;
 
 class BrowscapCacheTest extends PHPUnit_Framework_TestCase
 {
     public function testConstruct()
     {
-        $adapter = new NullStorage();
+        $adapter = new NullCache();
         $cache   = new BrowscapCache($adapter);
 
         $this->assertInstanceOf('BrowscapPHP\Cache\BrowscapCache', $cache);
@@ -19,7 +19,7 @@ class BrowscapCacheTest extends PHPUnit_Framework_TestCase
 
     public function testVersion()
     {
-        $adapter = new Memory();
+        $adapter = new ArrayCache();
         $cache   = new BrowscapCache($adapter);
 
         $this->assertNull($cache->getVersion());
@@ -30,7 +30,7 @@ class BrowscapCacheTest extends PHPUnit_Framework_TestCase
 
     public function testReleaseDate()
     {
-        $adapter = new Memory();
+        $adapter = new ArrayCache();
         $cache   = new BrowscapCache($adapter);
 
         $this->assertNull($cache->getVersion());
@@ -41,7 +41,7 @@ class BrowscapCacheTest extends PHPUnit_Framework_TestCase
 
     public function testType()
     {
-        $adapter = new Memory();
+        $adapter = new ArrayCache();
         $cache   = new BrowscapCache($adapter);
 
         $this->assertNull($cache->getType());

--- a/tests/Command/CheckUpdateCommandTest.php
+++ b/tests/Command/CheckUpdateCommandTest.php
@@ -4,7 +4,7 @@ namespace BrowscapPHPTest\Command;
 
 use BrowscapPHP\Cache\BrowscapCache;
 use BrowscapPHP\Command\CheckUpdateCommand;
-use WurflCache\Adapter\Memory;
+use Symfony\Component\Cache\Simple\ArrayCache;
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -51,7 +51,7 @@ class CheckUpdateCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $cacheAdapter   = new Memory();
+        $cacheAdapter   = new ArrayCache();
         $cache          = new BrowscapCache($cacheAdapter);
 
         $this->object = new CheckUpdateCommand('');

--- a/tests/Command/ConvertCommandTest.php
+++ b/tests/Command/ConvertCommandTest.php
@@ -5,7 +5,7 @@ namespace BrowscapPHPTest\Command;
 use BrowscapPHP\Cache\BrowscapCache;
 use BrowscapPHP\Command\ConvertCommand;
 use BrowscapPHP\Exception as BrowscapException;
-use WurflCache\Adapter\Memory;
+use Symfony\Component\Cache\Simple\ArrayCache; 
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -52,7 +52,7 @@ class ConvertCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $cacheAdapter   = new Memory();
+        $cacheAdapter   = new ArrayCache();
         $cache          = new BrowscapCache($cacheAdapter);
         $defaultIniFile = 'resources/browscap.ini';
 

--- a/tests/Command/LogfileCommandTest.php
+++ b/tests/Command/LogfileCommandTest.php
@@ -5,7 +5,7 @@ namespace BrowscapPHPTest\Command;
 use BrowscapPHP\Cache\BrowscapCache;
 use BrowscapPHP\Command\LogfileCommand;
 use org\bovigo\vfs\vfsStream;
-use WurflCache\Adapter\Memory;
+use Symfony\Component\Cache\Simple\ArrayCache;
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -54,7 +54,7 @@ class LogfileCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $cacheAdapter   = new Memory();
+        $cacheAdapter   = new ArrayCache();
         $cache          = new BrowscapCache($cacheAdapter);
 
         $this->object = new LogfileCommand('');

--- a/tests/Command/UpdateCommandTest.php
+++ b/tests/Command/UpdateCommandTest.php
@@ -4,7 +4,7 @@ namespace BrowscapPHPTest\Command;
 
 use BrowscapPHP\Cache\BrowscapCache;
 use BrowscapPHP\Command\UpdateCommand;
-use WurflCache\Adapter\Memory;
+use Symfony\Component\Cache\Simple\ArrayCache;
 
 /**
  * Browscap.ini parsing class with caching and update capabilities
@@ -51,7 +51,7 @@ class UpdateCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $cacheAdapter   = new Memory();
+        $cacheAdapter   = new ArrayCache();
         $cache          = new BrowscapCache($cacheAdapter);
 
         $this->object = new UpdateCommand('');

--- a/tests/CompareBrowscapWithOriginalTest.php
+++ b/tests/CompareBrowscapWithOriginalTest.php
@@ -5,7 +5,7 @@ namespace BrowscapPHPTest;
 use BrowscapPHP\Browscap;
 use BrowscapPHP\BrowscapUpdater;
 use BrowscapPHP\Cache\BrowscapCache;
-use WurflCache\Adapter\Memory;
+use Symfony\Component\Cache\Simple\ArrayCache;
 
 /**
  * Compares get_browser results for all matches in browscap.ini with results from Browscap class.
@@ -92,7 +92,7 @@ class CompareBrowscapWithOriginalTest extends \PHPUnit_Framework_TestCase
         // Now, load an INI file into BrowscapPHP\Browscap for testing the UAs
         self::$object = new Browscap();
 
-        $cacheAdapter = new Memory();
+        $cacheAdapter = new ArrayCache();
         $cache        = new BrowscapCache($cacheAdapter);
         $cache->flush();
 


### PR DESCRIPTION
Removed all references that I could find to the Wurfl cache implementation.

Sorry, I had removed the Memcache part of the README, Symfony does have a Memcache implementation but I didn't get around to updating the README with that information.

Should also note that this is using a dev version of the Symfony Cache since they haven't released a release version using PSR-16 yet (at least when I had made these changes)