### PR TITLE
Support pattern ids

### DIFF
--- a/src/Data/PropertyHolder.php
+++ b/src/Data/PropertyHolder.php
@@ -76,6 +76,7 @@ class PropertyHolder
             'Parent' => 1,
             'PropertyName' => 1,
             'CDF' => 1,
+            'PatternId' => 1,
         ];
 
         if (array_key_exists($propertyName, $stringProperties)) {

--- a/src/Formatter/PhpGetBrowser.php
+++ b/src/Formatter/PhpGetBrowser.php
@@ -142,6 +142,12 @@ class PhpGetBrowser implements FormatterInterface
             }
         }
 
+        // Don't want to normally do this, just if it exists in the data file
+        // for our test runs
+        if (array_key_exists('patternid', $this->settings)) {
+            $output->patternid = $this->settings['patternid'];
+        }
+
         return $output;
     }
 }

--- a/tests/Formatter/PhpGetBrowserTest.php
+++ b/tests/Formatter/PhpGetBrowserTest.php
@@ -68,4 +68,30 @@ class PhpGetBrowserTest extends \PHPUnit_Framework_TestCase
         self::assertSame('TestComment', $return->comment);
         self::assertObjectHasAttribute('browser_type', $return);
     }
+
+    public function testPatternIdIsReturned()
+    {
+        $data = [
+            'Browser' => 'test',
+            'PatternId' => 'test.json::u0::c1',
+        ];
+
+        $this->object->setData($data);
+        $return = $this->object->getData();
+
+        self::assertObjectHasAttribute('patternid', $return);
+        self::assertSame('test.json::u0::c1', $return->patternid);
+    }
+
+    public function testPatternIdIsNotReturned()
+    {
+        $data = [
+            'Browser' => 'test',
+        ];
+
+        $this->object->setData($data);
+        $return = $this->object->getData();
+
+        self::assertObjectNotHasAttribute('patternid', $return);
+    }
 }


### PR DESCRIPTION
This minor change is required for the coming soon changes to browscap/browscap for https://github.com/browscap/browscap/issues/1253

If the “PatternId” key is present in the data, the formatter will expose that property to the parser, otherwise it will not.

I didn’t want to add the key to the `defaultproperties` array as I don’t want it always exposed, only for the test runs that have pattern id collection enabled (which should only happen in the useragent test suite of browscap/browscap).

This “PatternId” key should not be present in normal parsing.