### PR TITLE
update version check

### DIFF
--- a/src/Exception/NoCachedVersionException.php
+++ b/src/Exception/NoCachedVersionException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+namespace BrowscapPHP\Exception;
+
+/**
+ * Exception to handle errors while fetching a remote file
+ */
+final class NoCachedVersionException extends DomainException
+{
+}

--- a/tests/BrowscapUpdaterTest.php
+++ b/tests/BrowscapUpdaterTest.php
@@ -1055,7 +1055,12 @@ AolVersion=0
 
         $this->object->setCache($cache);
 
-        self::assertSame(0, $this->object->checkUpdate());
+        $this->expectException(BrowscapException\NoCachedVersionException::class);
+        $this->expectExceptionMessage(
+            'there is no cached version available, please update from remote'
+        );
+
+        $this->object->checkUpdate();
     }
 
     public function testCheckUpdateWithException() : void


### PR DESCRIPTION
I updated the version check. When the remote version is empty, now a FetcherException is thrown.

Fixes #216.

This PR requires PR #214 to be merged before.