### PR TITLE
Allow Symfony 4.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "psr/simple-cache": "^1.0",
         "roave/doctrine-simplecache": "^1.1",
         "guzzlehttp/guzzle": "^6.2",
-        "symfony/filesystem": "^3.3",
-        "symfony/finder": "^3.3",
-        "symfony/console": "^3.3",
+        "symfony/filesystem": "^3.3 || ^4.0",
+        "symfony/finder": "^3.3 || ^4.0",
+        "symfony/console": "^3.3 || ^4.0",
         "monolog/monolog": "^1.23"
     },
     "require-dev": {


### PR DESCRIPTION
This PR allows Symfony 4.0 on composer.json in preparation for the Symfony 4.0 release on Nov 30 2017: http://symfony.com/blog/helping-prepare-for-symfony-4-bundle-support

#SymfonyConHackday2017