### PR TITLE
Allow PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ script: vendor/bin/phpunit -c phpunit.xml.dist --no-coverage --colors --verbose 
 jobs:
   fast_finish: true
   allow_failures:
-    - php: 7.2
     - php: nightly
   include:
     - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "source": "https://github.com/browscap/browscap-php"
     },
     "require": {
-        "php": "~7.1.0",
+        "php": ">=7.1.0,<7.3.0",
         "psr/simple-cache": "^1.0",
         "roave/doctrine-simplecache": "^1.1||^2.0",
         "guzzlehttp/guzzle": "^6.2",


### PR DESCRIPTION
In https://github.com/browscap/browscap-php/pull/222 the last commit disabled PHP 7.2, but Travis is green and I can't see reasons in the PR to do so.

May we re-enable 7.2?