### PR TITLE
Allow PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ jobs:
   allow_failures:
     - php: nightly
   include:
+    - php: 7.3
+      env: COMPOSER_FLAGS="--ignore-platform-reqs"
     - php: 7.2
       env: COMPOSER_FLAGS="--ignore-platform-reqs"
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "php": ">=7.1.0,<7.3.0",
+        "php": ">=7.1.0,<7.4.0",
         "daverandom/exceptional-json": "^1.0.4",
         "guzzlehttp/guzzle": "^6.2",
         "monolog/monolog": "^1.23",


### PR DESCRIPTION
Travis uses `--ignore-platform-reqs` and tests pass, but in the userland this is also needed to install browscap-php on PHP 7.3:

https://github.com/Roave/DoctrineSimpleCache/pull/30