### PR TITLE
Adding php 7.4 snapshot to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ jobs:
   fast_finish: true
   allow_failures:
     - php: nightly
+    - php: 7.4snapshot
   include:
+    - php: 7.4snapshot
+      env: COMPOSER_FLAGS="--ignore-platform-reqs"
     - php: 7.3
       env: COMPOSER_FLAGS="--ignore-platform-reqs"
     - php: 7.2


### PR DESCRIPTION
With PHP 7.4 on the horizon, would be nice to make sure tests pass against php 7.4 snapshot. Set to allowed failure for now.