### PR TITLE
Update guzzle to 7.4.5 due to security vulnerabilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": ">=7.4.3,<8.2.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.4.2",
+        "guzzlehttp/guzzle": "^7.4.5",
         "league/flysystem": "^2.4.5 || ^3.0.18",
         "matthiasmullie/scrapbook": "^1.4.8",
         "monolog/monolog": "^2.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c5fc2a96813f44bc8464a2f6982637d",
+    "content-hash": "7d409b48fe072246664c93c58917310b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1180,7 +1180,7 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -1227,7 +1227,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -4535,5 +4535,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
I updated browscap to work with guzzle 7.4.5 which is the next safe version for guzzle. Guzzle had some troubles with security lately. See https://packagist.org/packages/guzzlehttp/guzzle#7.4.5 and https://github.com/FriendsOfPHP/security-advisories/blob/master/guzzlehttp/guzzle/CVE-2022-29248.yaml for more information about it. 

We are using "^7.4.3" as version constraint for guzzle which is fine in most cases. I updated the version anyway, because there can be situations, where people still receive a problematic guzzle version. 

I found this while playing with security scanners in my company :). 