### PR TITLE
Allow Monolog 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "guzzlehttp/guzzle": "^7.4.5",
         "league/flysystem": "^2.4.5 || ^3.0.18",
         "matthiasmullie/scrapbook": "^1.4.8",
-        "monolog/monolog": "^2.5.0",
+        "monolog/monolog": "^2.5.0 || ^3.0.0",
         "psr/log": "^1.1.4 || ^2.0.0 || ^3.0.0",
         "psr/simple-cache": "^1.0.1 || ^2.0.0 || ^3.0.0",
         "symfony/console": "^v5.4.8 || ^v6.0.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d409b48fe072246664c93c58917310b",
+    "content-hash": "da8b7cf44c24de6e8e525cde840355e0",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
Might even be better to only require Monolog in a development environment / "require-dev" and to rely on "psr/log" instead?