### PR TITLE
Updated browscap-php to support symfony/console:7.4+

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yml
+++ b/.github/workflows/auto-merge-dependency-updates.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.0.0
+        uses: dependabot/fetch-metadata@v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/bin/browscap-php
+++ b/bin/browscap-php
@@ -22,8 +22,22 @@ if (!$foundVendorAutoload) {
 }
 
 use BrowscapPHP\Exception;
-use Symfony\Component\Console\Application;
 use BrowscapPHP\Command;
+use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Command\Command as ConsoleCommand;
+
+class Application extends ConsoleApplication {
+    public function add(callable|ConsoleCommand $command): ?ConsoleCommand
+    {
+        $symfonyConsoleVersion = Composer\InstalledVersions::getVersion('symfony/console');
+
+        if (version_compare($symfonyConsoleVersion, '7.4', '<')) {
+            return parent::add($command);
+        }
+
+        return parent::addCommand($command);
+    }
+}
 
 $cacheDirectory = $baseDir . '/resources/';
 $defaultIniFile = $baseDir . '/resources/browscap.ini';


### PR DESCRIPTION
Since Symfony 7.4, `Application::add` has been renamed `Application::addCommand`. If you're using browscap-php in an existing project that uses Symfony and you require a version of `symfony/console` with the new syntax then calls to `bin/browscap-php` will fail with:

```
Uncaught Error: Call to undefined method Symfony\Component\Console\Application::add() in /path/to/project/vendor/browscap/browscap-php/bin/browscap-php:32
```

To add support for the newer syntax while not breaking backwards compatibility I check the version of `symfony/console` installed and use the old or new syntax ass appropriate.

I'll note as well that this wasn't picked up when running tests - I only ran `phpunit` so unless there are other ways to test I think this file isn't covered, so that's probably why it wasn't picked up earlier.

Haven't made many PRs in my life so apologies if I've made a booboo somewhere.